### PR TITLE
Add Slack support via wee_slack.py

### DIFF
--- a/src/actions.yaml
+++ b/src/actions.yaml
@@ -1,2 +1,4 @@
 get-relay-password:
   description: "Return the relay password"
+update-wee-slack:
+  description: "Update the wee_slack script"

--- a/src/actions/update-wee-slack
+++ b/src/actions/update-wee-slack
@@ -1,0 +1,11 @@
+#!/usr/local/sbin/charm-env python3
+
+from lib_weechat import WeechatHelper
+from charmhelpers.core import hookenv
+
+helper = WeechatHelper()
+if helper.charm_config['enable-slack']:
+  helper.install_wee_slack()
+  hookenv.action_set({'outcome': 'success'})
+else:
+  hookenv.action_set({'outcome': 'failed'})

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -29,3 +29,7 @@ options:
     type: boolean
     default: false
     description: "If true use fqdn with the reverse proxy, if false use ip address"
+  enable-slack:
+    type: boolean
+    default: false
+    description: "When set to true, installs the wee_slack script to enable usage of Slack in WeeChat via the native WebSocket API"

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -10,5 +10,7 @@ options:
     packages:
       - weechat-curses
       - weechat-scripts
+      - python-websocket
+      - python3-websocket
       - encfs
 repo: https://github.com/pirate-charmers/layer-weechat

--- a/src/reactive/weechat.py
+++ b/src/reactive/weechat.py
@@ -40,6 +40,8 @@ def install_weechat():
     subprocess.check_call(['passwd', '-d', 'weechat'])
     if helper.charm_config['encfs-enabled']:
         setup_encfs()
+    if helper.charm_config['enable-slack']:
+        helper.install_wee_slack()
     helper.install_systemd()
     host.service('enable', 'weechat.service')
     host.service_start('weechat.service')
@@ -68,6 +70,12 @@ def configure_weechat():
 @when('weechat.configured')
 def apply_user_config():
     helper.apply_user_config()
+
+
+@when('config.changed.enable-slack')
+@when('weechat.installed')
+def install_wee_slack():
+    helper.install_wee_slack()
 
 
 @when('reverseproxy.ready')

--- a/src/tests/functional/test_deploy.py
+++ b/src/tests/functional/test_deploy.py
@@ -30,7 +30,8 @@ async def model():
 async def test_weechat_deploy(model, series):
     config = {'encfs-enabled': True,
               'encfs-password': 'test-password',
-              'relay-password': 'changeme'}
+              'relay-password': 'changeme',
+              'enable-slack': True}
     weechat = await model.deploy('{}/builds/weechat'.format(juju_repository),
                                  series=series,
                                  config=config)
@@ -81,3 +82,14 @@ async def test_get_relay_password(model):
         print(action)
         assert action.status == 'completed'
         assert action.results['password'] == 'changeme'
+
+
+async def test_update_wee_slack(model):
+    weechat = model.applications['weechat']
+    for unit in weechat.units:
+        # Run the action
+        action = await unit.run_action('update-wee-slack')
+        action = await action.wait()
+        print(unit)
+        print(action)
+        assert action.status == 'completed'

--- a/src/tests/unit/conftest.py
+++ b/src/tests/unit/conftest.py
@@ -35,6 +35,7 @@ def mock_hookenv_config(monkeypatch):
         # Load all defaults
         for key, value in yml['options'].items():
             cfg[key] = value['default']
+        cfg['enable-slack'] = True
 
         # Manually add cfg from other layers
         # cfg['my-other-layer'] = 'mock'
@@ -65,6 +66,64 @@ def mock_fchown(monkeypatch):
 
 
 @pytest.fixture
+def mock_install_remote(monkeypatch):
+
+    def return_tmp_dir(uri):
+        return '/tmp'
+
+    mock_method = mock.Mock()
+    mock_method.side_effect = return_tmp_dir
+    monkeypatch.setattr('lib_weechat.fetch.install_remote',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
+def mock_makedirs(monkeypatch):
+    mock_method = mock.Mock()
+    monkeypatch.setattr('lib_weechat.os.makedirs',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
+def mock_chownr(monkeypatch):
+    mock_method = mock.Mock()
+    monkeypatch.setattr('lib_weechat.host.chownr',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
+def mock_isfile(monkeypatch):
+
+    def return_true(filename):
+        return True
+
+    mock_method = mock.Mock()
+    mock_method.side_effect = return_true
+    monkeypatch.setattr('lib_weechat.os.path.isfile',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
+def mock_copyfile(monkeypatch):
+    mock_method = mock.Mock()
+    monkeypatch.setattr('lib_weechat.shutil.copyfile',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
+def mock_symlink(monkeypatch):
+    mock_method = mock.Mock()
+    monkeypatch.setattr('lib_weechat.host.symlink',
+                        mock_method)
+    return mock_method
+
+
+@pytest.fixture
 def mock_websocket(monkeypatch):
     mock_connection = mock.Mock()
     return_values = [b'\x00\x00\x00\x1a\x00\x00\x00\x00\x05_pongstr\x00\x00\x00\x0DHello Weechat',
@@ -82,7 +141,9 @@ def weechat_relay(mock_websocket):
 
 @pytest.fixture
 def weechat(tmpdir, mock_hookenv_config, mock_charm_dir, monkeypatch,
-            mock_fchown, mock_websocket, mock_hookenv_action):
+            mock_fchown, mock_makedirs, mock_chownr, mock_isfile,
+            mock_copyfile, mock_symlink, mock_websocket,
+            mock_install_remote, mock_hookenv_action):
     from lib_weechat import WeechatHelper
     helper = WeechatHelper()
 

--- a/src/tests/unit/test_actions.py
+++ b/src/tests/unit/test_actions.py
@@ -1,5 +1,4 @@
 import imp
-
 import mock
 
 
@@ -11,3 +10,30 @@ def test_get_relay_password(weechat, monkeypatch):
     assert mock_get.call_count == 0
     imp.load_source('get_relay_password', './actions/get-relay-password')
     assert mock_get.call_count == 1
+
+
+def test_update_weeslack(weechat, mock_install_remote,
+                         mock_symlink, mock_chownr, mock_isfile,
+                         mock_copyfile):
+    imp.load_source('update_wee_slack', './actions/update-wee-slack')
+    mock_install_remote.assert_called_once_with(
+        'https://github.com/wee-slack/wee-slack/archive/master.tar.gz'
+    )
+    mock_isfile.assert_called_once_with(
+        '/tmp/wee-slack-master/wee_slack.py'
+    )
+    mock_copyfile.assert_called_once_with(
+        '/tmp/wee-slack-master/wee_slack.py',
+        '/home/weechat/.weechat/python/wee_slack.py'
+    )
+    mock_symlink.assert_called_once_with(
+        '/home/weechat/.weechat/python/wee_slack.py',
+        '/home/weechat/.weechat/python/autoload/wee_slack.py'
+    )
+    mock_chownr.assert_called_once_with(
+        weechat.python_plugin_dir,
+        'weechat',
+        'weechat',
+        follow_links=True,
+        chowntopdir=True
+    )

--- a/src/tests/unit/test_lib.py
+++ b/src/tests/unit/test_lib.py
@@ -16,6 +16,32 @@ class TestLib():
             content = service_file.read()
             assert 'ExecStart=/usr/bin/screen -D -m -S weechat /usr/bin/weechat' in content
 
+    def test_install_weeslack(self, weechat, mock_install_remote,
+                              mock_symlink, mock_chownr, mock_isfile,
+                              mock_copyfile):
+        weechat.install_wee_slack()
+        mock_install_remote.assert_called_once_with(
+            'https://github.com/wee-slack/wee-slack/archive/master.tar.gz'
+        )
+        mock_isfile.assert_called_once_with(
+            '/tmp/wee-slack-master/wee_slack.py'
+        )
+        mock_copyfile.assert_called_once_with(
+            '/tmp/wee-slack-master/wee_slack.py',
+            '/home/weechat/.weechat/python/wee_slack.py'
+        )
+        mock_symlink.assert_called_once_with(
+            '/home/weechat/.weechat/python/wee_slack.py',
+            '/home/weechat/.weechat/python/autoload/wee_slack.py'
+        )
+        mock_chownr.assert_called_once_with(
+            weechat.python_plugin_dir,
+            'weechat',
+            'weechat',
+            follow_links=True,
+            chowntopdir=True
+        )
+    
     def test_generate_certificate(self, weechat):
         weechat.generate_certificate()
         with open(weechat.relay_cert_file, 'r') as cert_file:


### PR DESCRIPTION
This merge:
- Adds logic for installing python modules
- Installs the python websocket client library by default
- Adds the `enable-slack` configuration option
- Adds logic to download and update to latest `wee_slack.py` from [here](https://github.com/wee-slack/wee-slack/)
- Adds action for updating `wee_slack.py` ad-hoc
- Adds unit and functional tests for all of the above