### PR TITLE
Add support for IRC relay

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -3,6 +3,10 @@ options:
     type: int
     default: 9001
     description: "Weechat relay port"
+  irc-relay-port:
+    type: int
+    default: 6697
+    description: "Weechat IRC relay port"
   relay-password:
     type: string
     default: ""

--- a/src/lib/lib_weechat.py
+++ b/src/lib/lib_weechat.py
@@ -84,6 +84,7 @@ class WeechatHelper():
         self.weechat_command('/relay sslcertkey')
         self.weechat_command('/set relay.network.password {}'.format(self.relay_password))
         self.weechat_command('/relay add ssl.weechat {}'.format(self.charm_config['relay-port']))
+        self.weechat_command('/relay add ssl.irc {}'.format(self.charm_config['irc-relay-port']))
         self.weechat_command('/save')
 
     def ping_relay(self, hostname, port, secure=False):

--- a/src/reactive/weechat.py
+++ b/src/reactive/weechat.py
@@ -78,7 +78,7 @@ def configure_reverseproxy():
         internal_host = socket.getfqdn()
     else:
         internal_host = hookenv.unit_public_ip()
-    config = {
+    config = [{
         'mode': 'http',
         'urlbase': '/weechat',
         'external_port': 443,
@@ -88,5 +88,10 @@ def configure_reverseproxy():
         'ssl': True,
         'ssl-verify': False,
         'check': False,
-    }
+    }, {
+        'mode': 'tcp',
+        'external_port': 6697,
+        'internal_host': internal_host,
+        'internal_port': helper.charm_config['irc-relay-port'],
+    }]
     interface.configure(config)


### PR DESCRIPTION
This enables the IRC relay so that regular IRC clients can connect to WeeChat as a client.
This has a few limitations related to making buffers read - but those are more IRC protocol limitations rather than charm or WeeChat implementation issues, so it would be good to enable this and create a reverse proxy backend for it. 
The "enable-relay" option will enable both the WebSocket and IRC relays in order to simplify the UX.